### PR TITLE
Support storage of cache in an option

### DIFF
--- a/inc/class-cachestorageprovider.php
+++ b/inc/class-cachestorageprovider.php
@@ -91,17 +91,17 @@ class CacheStorageProvider extends StorageProvider {
 	/**
 	 * Registers a cache group for flushing.
 	 *
-	 * @param string $cache_group The cache group to be registered.
+	 * @param string $group The cache group to be registered.
 	 *
 	 * @return bool Whether the cache group was successfully registered.
 	 */
-	public function register_cache_group( string $cache_group ) : bool {
+	public function register_group( string $group ) : bool {
 		global $wp_object_cache;
 		if ( function_exists( 'wp_cache_add_redis_hash_groups' ) ) {
 			// Enable cache group flushing for this group
-			wp_cache_add_redis_hash_groups( $cache_group );
+			wp_cache_add_redis_hash_groups( $group );
 
-			return $wp_object_cache && isset( $wp_object_cache->redis_hash_groups[ $cache_group ] );
+			return $wp_object_cache && isset( $wp_object_cache->redis_hash_groups[ $group ] );
 		}
 
 		return false;

--- a/inc/class-cachestorageprovider.php
+++ b/inc/class-cachestorageprovider.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace HM\SwrCache;
+
+/**
+ *
+ */
+class CacheStorageProvider extends StorageProvider {
+	/**
+	 * Deletes a cache group and allows for immediate regeneration.
+	 *
+	 * @param string $cache_group The cache group to be deleted.
+	 *
+	 * @return bool Whether the cache group was successfully deleted.
+	 */
+	function delete_group( string $cache_group ) : bool {
+		// Requires cache group registration.
+		// @see \HM\SwrCache\register_cache_group
+		if ( function_exists( 'wp_cache_supports' ) && wp_cache_supports( 'flush_group' ) ) {
+			return wp_cache_flush_group( $cache_group );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Retrieves a cached form with its expiry time.
+	 *
+	 * @param string $cache_key The key of the cache to retrieve.
+	 * @param string $cache_group Optional. The cache group. Default is empty string.
+	 *
+	 * @return array An array containing the cached contents (or false) and its expiry timestamp.
+	 */
+	function get_with_expiry( string $cache_key, string $cache_group = '' ) : array {
+		$data = wp_cache_get( $cache_key, $cache_group );
+		$expiry_timestamp = (int) wp_cache_get( $cache_key . '_expiry', $cache_group );
+
+		return [ $data, $expiry_timestamp ];
+	}
+
+	/**
+	 * Set data in cache with expiry and delete the lock transient.
+	 *
+	 * @param string $lock_key The name of the lock.
+	 * @param mixed  $data The data to be cached.
+	 * @param int    $cache_duration The expiry time for the cache in seconds.
+	 * @param string $cache_key The key for the cache.
+	 * @param string $cache_group Optional. The group for the cache. Default value is empty string.
+	 */
+	public function set_with_expiry( string $lock_key, mixed $data, int $cache_duration, string $cache_key, string $cache_group = '' ) : void {
+		wp_cache_set( $cache_key, $data, $cache_group );
+
+		wp_cache_set( $cache_key . '_expiry', time() + $cache_duration, $cache_group, $cache_duration );
+		wp_cache_delete( $lock_key, $cache_group );
+	}
+
+	/**
+	 * Adds a lock key in the cache to avoid race conditions and enables synchronization between processes.
+	 * It's only stored if the lock doesn't exist (or is expired).
+	 *
+	 * @param string $lock_key The unique key for the lock.
+	 * @param string $cache_group The cache group where the lock key will be stored
+	 * @param int    $lock_time The duration in seconds for which the lock will be held. Default is MINUTE_IN_SECONDS constant.
+	 *
+	 * @return string The generated lock value, unique per invocation, regardless whether the lock is added.
+	 */
+	function lock_add( string $lock_key, string $cache_group = '', int $lock_time = MINUTE_IN_SECONDS ) : string {
+		$lock_value = wp_generate_uuid4();
+		// Add will fail if it already exists.
+		wp_cache_add( $lock_key, $lock_value, $cache_group, $lock_time );
+
+		return $lock_value;
+	}
+}

--- a/inc/class-cachestorageprovider.php
+++ b/inc/class-cachestorageprovider.php
@@ -71,4 +71,39 @@ class CacheStorageProvider extends StorageProvider {
 
 		return $lock_value;
 	}
+
+	/**
+	 * Verifies the lock against the cached lock.
+	 *
+	 * @param string $lock_key The transient key used to lock the group.
+	 * @param string $lock_value The lock value to be verified.
+	 * @param string $cache_group The cache group in which the lock value is stored. Default is an empty string.
+	 *
+	 * @return bool Whether the lock value matches the cached lock value in the cache group.
+	 */
+	function lock_verify( string $lock_key, string $lock_value, string $cache_group = '' ) : bool {
+		$found = null;
+		$cached_lock = wp_cache_get( $lock_key, $cache_group, false, $found );
+
+		return $found && $cached_lock === $lock_value;
+	}
+
+	/**
+	 * Registers a cache group for flushing.
+	 *
+	 * @param string $cache_group The cache group to be registered.
+	 *
+	 * @return bool Whether the cache group was successfully registered.
+	 */
+	public function register_cache_group( string $cache_group ) : bool {
+		global $wp_object_cache;
+		if ( function_exists( 'wp_cache_add_redis_hash_groups' ) ) {
+			// Enable cache group flushing for this group
+			wp_cache_add_redis_hash_groups( $cache_group );
+
+			return $wp_object_cache && isset( $wp_object_cache->redis_hash_groups[ $cache_group ] );
+		}
+
+		return false;
+	}
 }

--- a/inc/class-optionstorageprovider.php
+++ b/inc/class-optionstorageprovider.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace HM\SwrCache;
+
+/**
+ * Option groups do not exists so we're using a prefix.
+ */
+class OptionStorageProvider extends StorageProvider {
+	/**
+	 * Deletes a cache group and allows for immediate regeneration.
+	 *
+	 * @param string $cache_group The option group to be deleted.
+	 *
+	 * @return bool Always false as option groups do not exist.
+	 */
+	public function delete_group( string $cache_group ) : bool {
+		// Option groups do not exist
+		// TODO: Do a database search for all options with a prefix?
+		return false;
+	}
+
+	/**
+	 * Retrieves a cached form with its expiry time.
+	 *
+	 * @param string $cache_key The key of the cache to retrieve.
+	 * @param string $cache_group Optional. The cache group. Default is empty string.
+	 *
+	 * @return array An array containing the cached contents (or false) and its expiry timestamp.
+	 */
+	public function get_with_expiry( string $cache_key, string $cache_group = '' ) : array {
+		$data = get_option( $this->dashit( $cache_group ) . $cache_key );
+		$expiry_timestamp = (int) get_option( $this->dashit( $cache_group ) . $cache_key . '_expiry' );
+
+		return [ $data, $expiry_timestamp ];
+	}
+
+	/**
+	 * Add a dash to the end of a string if it is not empty.
+	 *
+	 * @param string $str The string to append the dash to.
+	 *
+	 * @return string The modified string.
+	 */
+	protected function dashit( $str ) : string {
+		return $str ? $str . '-' : $str;
+	}
+
+	/**
+	 * Set data in cache with expiry and delete the lock transient.
+	 *
+	 * @param string $lock_key The name of the lock.
+	 * @param mixed  $data The data to be cached.
+	 * @param int    $cache_duration The expiry time for the cache in seconds.
+	 * @param string $cache_key The key for the cache.
+	 * @param string $cache_group Optional. The group for the cache. Default value is empty string.
+	 */
+	public function set_with_expiry( string $lock_key, mixed $data, int $cache_duration, string $cache_key, string $cache_group = '' ) : void {
+		update_option( $this->dashit( $cache_group ) . $cache_key, $data, false ); // Don't autoload.
+		set_transient( $this->dashit( $cache_group ) . $cache_key . '_expiry', time() + $cache_duration, $cache_duration );
+		delete_transient( $this->dashit( $cache_group ) . $lock_key );
+	}
+
+	/**
+	 * Adds a lock key in the cache to avoid race conditions and enables synchronization between processes.
+	 * It's only stored if the lock doesn't exist (or is expired).
+	 *
+	 * @param string $lock_key The unique key for the lock.
+	 * @param string $cache_group The cache group where the lock key will be stored
+	 * @param int    $lock_time The duration in seconds for which the lock will be held. Default is MINUTE_IN_SECONDS constant.
+	 *
+	 * @return string The generated lock value, unique per invocation, regardless whether the lock is added.
+	 */
+	public function lock_add( string $lock_key, string $cache_group = '', int $lock_time = MINUTE_IN_SECONDS ) : string {
+		$lock_value = wp_generate_uuid4();
+		// Add will fail if it already exists.
+		$this->add_transient( $lock_key, $lock_value, $cache_group, $lock_time );
+
+		return $lock_value;
+	}
+
+	/**
+	 * Adds a transient value to the cache.
+	 *
+	 * @param string $key The key of the transient value.
+	 * @param mixed  $data The data to be stored in the transient value.
+	 * @param string $group The cache group where the transient value will be stored. Default is an empty string.
+	 * @param int    $expire The duration in seconds for which the transient value will be stored. Default is 0, which means no expiration.
+	 *
+	 * @return bool True if the transient value was successfully added to the cache, false if the key and group already exists.
+	 */
+	protected function add_transient( string $key, mixed $data, string $group = '', int $expire = 0 ) : bool {
+		$group = $this->dashit( $group );
+		if ( get_transient( $group . $key ) ) {
+			return false;
+		}
+		$transient = $group . $key;
+
+		return set_transient( $transient, $data, $expire );
+	}
+}

--- a/inc/class-storageprovider.php
+++ b/inc/class-storageprovider.php
@@ -1,16 +1,38 @@
 <?php
+/**
+ * Abstract class to define a Storage Provider which can be implemented by a backend.
+ */
 
 namespace HM\SwrCache;
 
-abstract class StorageProvider {
-	public const CACHE = __NAMESPACE__ .'\\CacheStorageProvider';
-	public const OPTION = __NAMESPACE__ . '\\OptionStorageProvider';
-	private static $instance;
+use InvalidArgumentException;
 
-	public static function getInstance( $provider_type = self::CACHE ) {
-		if ( ! self::$instance ) {
+/**
+ * Abstract class to define a Storage Provider for caching functionality.
+ */
+abstract class StorageProvider {
+	public const CACHE = CacheStorageProvider::class;
+	public const TRANSOPTION = TransoptionStorageProvider::class;
+	private const ALLOWED_CACHE_STORAGE = [ StorageProvider::CACHE, StorageProvider::TRANSOPTION ];
+	/** @var StorageProvider */
+	private static StorageProvider $instance;
+
+	/**
+	 * Retrieves an instance of the cache provider based on the provider type.
+	 *
+	 * @param string $provider_type The type of cache provider to retrieve.
+	 *
+	 * @return self The instance of the cache provider.
+	 * @throws InvalidArgumentException If the given provider type is not a valid class or cache storage type.
+	 */
+	public static function get_instance( string $provider_type ) : self {
+		if ( ! isset( self::$instance ) || self::$instance === null ) {
 			if ( ! class_exists( $provider_type ) ) {
-				throw new \InvalidArgumentException( "Class '$provider_type' does not exist" );
+				throw new InvalidArgumentException( "Class '$provider_type' does not exist" );
+			}
+			// TODO: allow for custom storage providers.
+			if ( ! in_array( $provider_type, self::ALLOWED_CACHE_STORAGE, true ) ) {
+				throw new InvalidArgumentException( sprintf( 'Cache storage type not valid. Expected one of %s', implode( ', ', self::ALLOWED_CACHE_STORAGE ) ) );
 			}
 			self::$instance = new $provider_type;
 		}
@@ -46,7 +68,7 @@ abstract class StorageProvider {
 	 * @param string $cache_key The key for the cache.
 	 * @param string $cache_group Optional. The group for the cache. Default value is empty string.
 	 */
-	abstract function set_with_expiry( string $lock_key, mixed $data, int $cache_duration, string $cache_key, string $cache_group = '' ) : void;
+	abstract public function set_with_expiry( string $lock_key, mixed $data, int $cache_duration, string $cache_key, string $cache_group = '' ) : void;
 
 	/**
 	 * Adds a lock key in the cache to avoid race conditions and enables synchronization between processes.
@@ -58,5 +80,25 @@ abstract class StorageProvider {
 	 *
 	 * @return string The generated lock value, unique per invocation, regardless whether the lock is added.
 	 */
-	abstract function lock_add( string $lock_key, string $cache_group = '', int $lock_time = MINUTE_IN_SECONDS ) : string;
+	abstract public function lock_add( string $lock_key, string $cache_group = '', int $lock_time = MINUTE_IN_SECONDS ) : string;
+
+	/**
+	 * Verifies the lock against the cached lock.
+	 *
+	 * @param string $lock_key The transient key used to lock the group.
+	 * @param string $lock_value The lock value to be verified.
+	 * @param string $cache_group The cache group in which the lock value is stored. Default is an empty string.
+	 *
+	 * @return bool Whether the lock value matches the cached lock value in the cache group.
+	 */
+	abstract public function lock_verify( string $lock_key, string $lock_value, string $cache_group = '' ) : bool;
+
+	/**
+	 * Registers a cache group for flushing.
+	 *
+	 * @param string $cache_group The cache group to be registered.
+	 *
+	 * @return bool Whether the cache group was successfully registered.
+	 */
+	abstract public function register_cache_group( string $cache_group ) : bool;
 }

--- a/inc/class-storageprovider.php
+++ b/inc/class-storageprovider.php
@@ -96,9 +96,9 @@ abstract class StorageProvider {
 	/**
 	 * Registers a cache group for flushing.
 	 *
-	 * @param string $cache_group The cache group to be registered.
+	 * @param string $group The cache group to be registered.
 	 *
 	 * @return bool Whether the cache group was successfully registered.
 	 */
-	abstract public function register_cache_group( string $cache_group ) : bool;
+	abstract public function register_group( string $group ) : bool;
 }

--- a/inc/class-storageprovider.php
+++ b/inc/class-storageprovider.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace HM\SwrCache;
+
+abstract class StorageProvider {
+	public const CACHE = __NAMESPACE__ .'\\CacheStorageProvider';
+	public const OPTION = __NAMESPACE__ . '\\OptionStorageProvider';
+	private static $instance;
+
+	public static function getInstance( $provider_type = self::CACHE ) {
+		if ( ! self::$instance ) {
+			if ( ! class_exists( $provider_type ) ) {
+				throw new \InvalidArgumentException( "Class '$provider_type' does not exist" );
+			}
+			self::$instance = new $provider_type;
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Deletes a cache group and allows for immediate regeneration.
+	 *
+	 * @param string $cache_group The cache group to be deleted.
+	 *
+	 * @return bool Whether the cache group was successfully deleted.
+	 */
+	abstract public function delete_group( string $cache_group ) : bool;
+
+	/**
+	 * Retrieves a cached form with its expiry time.
+	 *
+	 * @param string $cache_key The key of the cache to retrieve.
+	 * @param string $cache_group Optional. The cache group. Default is empty string.
+	 *
+	 * @return array An array containing the cached contents (or false) and its expiry timestamp.
+	 */
+	abstract public function get_with_expiry( string $cache_key, string $cache_group = '' ) : array;
+
+	/**
+	 * Set data in cache with expiry and delete the lock transient.
+	 *
+	 * @param string $lock_key The name of the lock.
+	 * @param mixed  $data The data to be cached.
+	 * @param int    $cache_duration The expiry time for the cache in seconds.
+	 * @param string $cache_key The key for the cache.
+	 * @param string $cache_group Optional. The group for the cache. Default value is empty string.
+	 */
+	abstract function set_with_expiry( string $lock_key, mixed $data, int $cache_duration, string $cache_key, string $cache_group = '' ) : void;
+
+	/**
+	 * Adds a lock key in the cache to avoid race conditions and enables synchronization between processes.
+	 * It's only stored if the lock doesn't exist (or is expired).
+	 *
+	 * @param string $lock_key The unique key for the lock.
+	 * @param string $cache_group The cache group where the lock key will be stored
+	 * @param int    $lock_time The duration in seconds for which the lock will be held. Default is MINUTE_IN_SECONDS constant.
+	 *
+	 * @return string The generated lock value, unique per invocation, regardless whether the lock is added.
+	 */
+	abstract function lock_add( string $lock_key, string $cache_group = '', int $lock_time = MINUTE_IN_SECONDS ) : string;
+}

--- a/inc/class-transoptionstorageprovider.php
+++ b/inc/class-transoptionstorageprovider.php
@@ -7,7 +7,7 @@ namespace HM\SwrCache;
  */
 class TransoptionStorageProvider extends StorageProvider {
 
-	private array $registered_cache_groups = [];
+	private array $registered_groups = [];
 	/**
 	 * Deletes a cache group and allows for immediate regeneration.
 	 *
@@ -21,7 +21,7 @@ class TransoptionStorageProvider extends StorageProvider {
 		global $wpdb;
 
 		// cache groups must be registered first.
-		if ( ! isset( $this->registered_cache_groups[ $cache_group ] ) ) {
+		if ( ! isset( $this->registered_groups[ $cache_group ] ) ) {
 			return false;
 		}
 
@@ -40,12 +40,12 @@ class TransoptionStorageProvider extends StorageProvider {
 		/**
 		 * Registers a cache group for flushing.
 		 *
-		 * @param string $cache_group The cache group to be registered.
+		 * @param string $group The cache group to be registered.
 		 *
 		 * @return bool Whether the cache group was successfully registered.
 		 */
-	public function register_cache_group( string $cache_group ) : bool {
-		$this->registered_cache_groups[ $cache_group ] = $cache_group;
+	public function register_group( string $group ) : bool {
+		$this->registered_groups[ $group ] = $group;
 		return true;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -147,5 +147,5 @@ function get( string $cache_key, string $cache_group, callable $callback, array 
 function register_cache_group( string $cache_group ) : bool {
 	global $storage;
 
-	return $storage->register_cache_group( $cache_group );
+	return $storage->register_group( $cache_group );
 }

--- a/plugin.php
+++ b/plugin.php
@@ -7,7 +7,7 @@ namespace HM\SwrCache;
 
 require_once __DIR__ . '/inc/class-storageprovider.php';
 require_once __DIR__ . '/inc/class-cachestorageprovider.php';
-require_once __DIR__ . '/inc/class-optionstorageprovider.php';
+require_once __DIR__ . '/inc/class-transoptionstorageprovider.php';
 require_once __DIR__ . '/inc/namespace.php';
 
 bootstrap();

--- a/plugin.php
+++ b/plugin.php
@@ -5,6 +5,9 @@
 
 namespace HM\SwrCache;
 
+require_once __DIR__ . '/inc/class-storageprovider.php';
+require_once __DIR__ . '/inc/class-cachestorageprovider.php';
+require_once __DIR__ . '/inc/class-optionstorageprovider.php';
 require_once __DIR__ . '/inc/namespace.php';
 
 bootstrap();


### PR DESCRIPTION
Allow specifying storage of cache data in an option. This ensures it's persistent even after cache being flushed. 